### PR TITLE
Replace the org.json dependency by openjson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.tdunning</groupId>
-      <artifactId>json</artifactId>
-      <version>1.8</version>
+      <groupId>com.github.openjson</groupId>
+      <artifactId>openjson</artifactId>
+      <version>1.0.11</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,11 @@
     </dependency>
 
     <dependency>
-      <groupId>org.json</groupId>
+      <groupId>com.tdunning</groupId>
       <artifactId>json</artifactId>
-      <version>20131018</version>
+      <version>1.8</version>
     </dependency>
+
     <dependency>
       <groupId>org.htmlparser</groupId>
       <artifactId>htmlparser</artifactId>

--- a/src/main/java/org/archive/extract/DumpingExtractorOutput.java
+++ b/src/main/java/org/archive/extract/DumpingExtractorOutput.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 import org.archive.resource.Resource;
 import org.archive.util.StreamCopy;
-import org.json.JSONException;
+import com.github.openjson.JSONException;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;

--- a/src/main/java/org/archive/extract/ExtractingResourceFactoryMapper.java
+++ b/src/main/java/org/archive/extract/ExtractingResourceFactoryMapper.java
@@ -20,8 +20,8 @@ import org.archive.resource.warc.WARCResource;
 import org.archive.resource.warc.record.DNSResourceFactory;
 import org.archive.resource.warc.record.WARCJSONMetaDataResourceFactory;
 import org.archive.resource.warc.record.WARCMetaDataResourceFactory;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class ExtractingResourceFactoryMapper implements ResourceFactoryMapper {
 

--- a/src/main/java/org/archive/extract/RealCDXExtractorOutput.java
+++ b/src/main/java/org/archive/extract/RealCDXExtractorOutput.java
@@ -21,9 +21,9 @@ import org.archive.url.URLKeyMaker;
 import org.archive.url.WaybackURLKeyMaker;
 import org.archive.util.IAUtils;
 import org.archive.util.StreamCopy;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;

--- a/src/main/java/org/archive/extract/WARCMetadataRecordExtractorOutput.java
+++ b/src/main/java/org/archive/extract/WARCMetadataRecordExtractorOutput.java
@@ -18,9 +18,9 @@ import org.archive.resource.MetaData;
 import org.archive.resource.Resource;
 import org.archive.util.IAUtils;
 import org.archive.util.StreamCopy;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;

--- a/src/main/java/org/archive/extract/WATExtractorOutput.java
+++ b/src/main/java/org/archive/extract/WATExtractorOutput.java
@@ -22,7 +22,7 @@ import org.archive.util.IAUtils;
 import org.archive.util.DateUtils;
 import org.archive.util.StreamCopy;
 import org.archive.util.io.CommitedOutputStream;
-import org.json.JSONException;
+import com.github.openjson.JSONException;
 
 import java.net.InetAddress;
 import java.text.DateFormat;

--- a/src/main/java/org/archive/extract/WATExtractorOutput.java
+++ b/src/main/java/org/archive/extract/WATExtractorOutput.java
@@ -177,12 +177,8 @@ public class WATExtractorOutput implements ExtractorOutput {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
 
 		OutputStreamWriter osw = new OutputStreamWriter(bos, UTF8);
-		try {
-			md.write(osw);
-		} catch (JSONException e1) {
-			e1.printStackTrace();
-			throw new IOException(e1);
-		}
+		String contents = md.toString();
+		osw.write(contents, 0, contents.length());
 		osw.flush();
 //		ByteArrayInputStream bais = new ByteArrayInputStream(md.toString().getBytes("UTF-8"));
 		Date capDate;

--- a/src/main/java/org/archive/format/arc/FiledescRecord.java
+++ b/src/main/java/org/archive/format/arc/FiledescRecord.java
@@ -2,9 +2,9 @@ package org.archive.format.arc;
 
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class FiledescRecord {
 	private static final Logger LOG = 

--- a/src/main/java/org/archive/format/json/CompoundORJSONPathSpec.java
+++ b/src/main/java/org/archive/format/json/CompoundORJSONPathSpec.java
@@ -3,7 +3,7 @@ package org.archive.format.json;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.json.JSONObject;
+import com.github.openjson.JSONObject;
 
 public class CompoundORJSONPathSpec implements JSONPathSpec {
 	ArrayList<JSONPathSpec> parts;

--- a/src/main/java/org/archive/format/json/JSONPathSpec.java
+++ b/src/main/java/org/archive/format/json/JSONPathSpec.java
@@ -2,7 +2,7 @@ package org.archive.format.json;
 
 import java.util.List;
 
-import org.json.JSONObject;
+import com.github.openjson.JSONObject;
 
 public interface JSONPathSpec {
 	public static final String EMPTY = "";

--- a/src/main/java/org/archive/format/json/JSONUtils.java
+++ b/src/main/java/org/archive/format/json/JSONUtils.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class JSONUtils {
 	private static final Logger LOG =

--- a/src/main/java/org/archive/format/json/JSONView.java
+++ b/src/main/java/org/archive/format/json/JSONView.java
@@ -6,7 +6,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
-import org.json.JSONObject;
+import com.github.openjson.JSONObject;
 
 /**
  * 

--- a/src/main/java/org/archive/format/json/SimpleJSONPathSpec.java
+++ b/src/main/java/org/archive/format/json/SimpleJSONPathSpec.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class SimpleJSONPathSpec implements JSONPathSpec {
 	private static final Logger LOG =

--- a/src/main/java/org/archive/hadoop/ArchiveJSONViewLoader.java
+++ b/src/main/java/org/archive/hadoop/ArchiveJSONViewLoader.java
@@ -11,8 +11,8 @@ import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.archive.format.json.JSONView;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class ArchiveJSONViewLoader extends ArchiveMetadataLoader {
 	private final static Logger LOG = 

--- a/src/main/java/org/archive/hadoop/func/JSONViewEvalFunc.java
+++ b/src/main/java/org/archive/hadoop/func/JSONViewEvalFunc.java
@@ -8,8 +8,8 @@ import org.apache.pig.EvalFunc;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.archive.format.json.JSONUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class JSONViewEvalFunc extends EvalFunc<Tuple> {
 	private static final Logger LOG =

--- a/src/main/java/org/archive/io/WriterPool.java
+++ b/src/main/java/org/archive/io/WriterPool.java
@@ -30,9 +30,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 /**
  * Pool of Writers.

--- a/src/main/java/org/archive/resource/MetaData.java
+++ b/src/main/java/org/archive/resource/MetaData.java
@@ -2,10 +2,10 @@ package org.archive.resource;
 
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
+import com.github.openjson.JSONTokener;
 
 public class MetaData extends JSONObject {
 

--- a/src/main/java/org/archive/resource/gzip/GZIPMetaData.java
+++ b/src/main/java/org/archive/resource/gzip/GZIPMetaData.java
@@ -12,8 +12,8 @@ import org.archive.format.gzip.GZIPStaticHeader;
 import org.archive.resource.MetaData;
 import org.archive.resource.ResourceConstants;
 import org.archive.util.ByteOp;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class GZIPMetaData extends MetaData implements ResourceConstants {
 	private static final Logger LOG = Logger.getLogger(GZIPMetaData.class.getName());

--- a/src/main/java/org/archive/resource/html/HTMLMetaData.java
+++ b/src/main/java/org/archive/resource/html/HTMLMetaData.java
@@ -5,9 +5,9 @@ import java.util.logging.Logger;
 
 import org.archive.resource.MetaData;
 import org.archive.resource.ResourceConstants;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class HTMLMetaData extends MetaData implements ResourceConstants {
 

--- a/src/main/java/org/archive/resource/html/HTMLResourceFactory.java
+++ b/src/main/java/org/archive/resource/html/HTMLResourceFactory.java
@@ -20,8 +20,8 @@ import org.archive.resource.ResourceFactory;
 import org.archive.resource.ResourceParseException;
 import org.htmlparser.lexer.Page;
 import org.htmlparser.util.ParserException;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class HTMLResourceFactory implements ResourceFactory {
 

--- a/src/main/java/org/archive/resource/warc/record/DNSResource.java
+++ b/src/main/java/org/archive/resource/warc/record/DNSResource.java
@@ -9,8 +9,8 @@ import org.archive.resource.AbstractEmptyResource;
 import org.archive.resource.MetaData;
 import org.archive.resource.ResourceConstants;
 import org.archive.resource.ResourceContainer;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 public class DNSResource extends AbstractEmptyResource implements ResourceConstants {
 	private static final Logger LOG = 

--- a/src/main/java/org/archive/resource/warc/record/WARCJSONMetaDataResourceFactory.java
+++ b/src/main/java/org/archive/resource/warc/record/WARCJSONMetaDataResourceFactory.java
@@ -11,8 +11,8 @@ import org.archive.resource.ResourceConstants;
 import org.archive.resource.ResourceContainer;
 import org.archive.resource.ResourceFactory;
 import org.archive.resource.ResourceParseException;
-import org.json.JSONException;
-import org.json.JSONTokener;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONTokener;
 
 public class WARCJSONMetaDataResourceFactory implements ResourceFactory, ResourceConstants {
 	private static final Charset UTF8 = Charset.forName("UTF-8");

--- a/src/test/java/org/archive/format/json/CompoundORJSONPathSpecTest.java
+++ b/src/test/java/org/archive/format/json/CompoundORJSONPathSpecTest.java
@@ -3,8 +3,8 @@ package org.archive.format.json;
 import java.util.ArrayList;
 
 import org.archive.util.TestUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/archive/format/json/JSONPathSpecFactoryTest.java
+++ b/src/test/java/org/archive/format/json/JSONPathSpecFactoryTest.java
@@ -1,8 +1,8 @@
 package org.archive.format.json;
 
 import org.archive.util.TestUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/archive/format/json/JSONViewTest.java
+++ b/src/test/java/org/archive/format/json/JSONViewTest.java
@@ -1,8 +1,8 @@
 package org.archive.format.json;
 
 import org.archive.util.TestUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/archive/format/json/SimpleJSONPathSpecTest.java
+++ b/src/test/java/org/archive/format/json/SimpleJSONPathSpecTest.java
@@ -1,8 +1,8 @@
 package org.archive.format.json;
 
 import org.archive.util.TestUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -16,9 +16,9 @@ import org.archive.resource.ResourceParseException;
 import org.archive.resource.ResourceProducer;
 import org.htmlparser.nodes.TextNode;
 import org.htmlparser.util.Translate;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;

--- a/src/test/java/org/archive/resource/html/HTMLMetaDataTest.java
+++ b/src/test/java/org/archive/resource/html/HTMLMetaDataTest.java
@@ -1,8 +1,8 @@
 package org.archive.resource.html;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONObject;
 
 import junit.framework.TestCase;
 


### PR DESCRIPTION
(cf. #15 and #16)
- fixes incompatible license, see
  https://wiki.debian.org/qa.debian.org/jsonevil
  https://lwn.net/Articles/707510/
- improves performance when writing JSON