### PR TITLE
WAT: only unescape complete XML/HTML character entities (fixes #19)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,9 +151,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.7</version>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.12.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,13 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.5</version>
+      <version>2.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.7</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -16,7 +16,6 @@ import org.htmlparser.Attribute;
 import org.htmlparser.nodes.RemarkNode;
 import org.htmlparser.nodes.TagNode;
 import org.htmlparser.nodes.TextNode;
-import org.htmlparser.util.Translate;
 
 public class ExtractingParseObserver implements ParseObserver {
 
@@ -199,7 +198,7 @@ public class ExtractingParseObserver implements ParseObserver {
 				if((vals != null) && (vals.size() > 0)) {
 					if(text != null) {
 						// contained an href - we want to ignore <a name="X"></a>:
-						String trimmed = wsPattern.matcher(decodeCharEnt(text.toString()).trim()).replaceAll(" ");
+						String trimmed = wsPattern.matcher(decodeCharEnt(text.toString(), false).trim()).replaceAll(" ");
 						if(trimmed.length() > MAX_TEXT_LEN) {
 							trimmed = trimmed.substring(0,MAX_TEXT_LEN);
 						}
@@ -221,7 +220,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		// this result is thrown away.
 
 		String txt = text.getText();
-		txt = decodeCharEnt(txt);
+		txt = decodeCharEnt(txt, false);
 		if (inPre) {
 			textExtract.append(txt);
 		} else {
@@ -611,9 +610,18 @@ public class ExtractingParseObserver implements ParseObserver {
 	}
 
 	public static String decodeCharEnt(String text) {
+		return decodeCharEnt(text, true);
+	}
+
+	public static String decodeCharEnt(String text, boolean inAttribute) {
+		if (text.indexOf('&') == -1) {
+			return text;
+		}
 		try {
-			return org.apache.commons.text.StringEscapeUtils.unescapeHtml4(text);
+			return org.jsoup.parser.Parser.unescapeEntities(text, inAttribute);
 		} catch (Throwable e) {
+			System.err.println(text);
+			e.printStackTrace();
 			return text;
 		}
 	}

--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -163,7 +163,7 @@ public class ExtractingParseObserver implements ParseObserver {
 			}
 			attrName = attrName.toLowerCase(Locale.ROOT);
 			if (globalHrefAttributes.contains(attrName)) {
-				attrValue = Translate.decode(attrValue);
+				attrValue = decodeCharEnt(attrValue);
 				data.addHref(PATH,makePath(name,attrName),"url",attrValue);
 			}
 		}
@@ -199,7 +199,7 @@ public class ExtractingParseObserver implements ParseObserver {
 				if((vals != null) && (vals.size() > 0)) {
 					if(text != null) {
 						// contained an href - we want to ignore <a name="X"></a>:
-						String trimmed = wsPattern.matcher(Translate.decode(text.toString()).trim()).replaceAll(" ");
+						String trimmed = wsPattern.matcher(decodeCharEnt(text.toString()).trim()).replaceAll(" ");
 						if(trimmed.length() > MAX_TEXT_LEN) {
 							trimmed = trimmed.substring(0,MAX_TEXT_LEN);
 						}
@@ -221,7 +221,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		// this result is thrown away.
 
 		String txt = text.getText();
-		txt = Translate.decode(txt);
+		txt = decodeCharEnt(txt);
 		if (inPre) {
 			textExtract.append(txt);
 		} else {
@@ -274,7 +274,7 @@ public class ExtractingParseObserver implements ParseObserver {
 	}
 
 	public void handleStyleNode(TextNode text) {
-		String cssStr = Translate.decode(text.getText());
+		String cssStr = decodeCharEnt(text.getText());
 		patternCSSExtract(data, cssUrlPattern, cssStr);
 		patternCSSExtract(data, cssImportNoUrlPattern, cssStr);
 	}
@@ -303,7 +303,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		for(String attr : attrs) {
 			String val = node.getAttribute(attr);
 			if(val != null) {
-				val = Translate.decode(val);
+				val = decodeCharEnt(val);
 				data.addHref(PATH,makePath(node.getTagName(),attr),"url",val);
 			}
 		}
@@ -314,7 +314,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		for(String attr : attrs) {
 			String val = node.getAttribute(attr);
 			if(val != null) {
-				val = Translate.decode(val);
+				val = decodeCharEnt(val);
 				l.add(attr);
 				l.add(val);
 			}
@@ -330,7 +330,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		String url = node.getAttribute(urlAttr);
 		ArrayList<String> l = null;
 		if(url != null) {
-			url = Translate.decode(url);
+			url = decodeCharEnt(url);
 			l = new ArrayList<String>();
 			l.add(PATH);
 			l.add(makePath(node.getTagName(),urlAttr));
@@ -340,7 +340,7 @@ public class ExtractingParseObserver implements ParseObserver {
 			for(String attr : optionalAttrs) {
 				String val = node.getAttribute(attr);
 				if(val != null) {
-					val = Translate.decode(val);
+					val = decodeCharEnt(val);
 					l.add(attr);
 					l.add(val);
 				}
@@ -404,7 +404,7 @@ public class ExtractingParseObserver implements ParseObserver {
 			String url = node.getAttribute("href");
 			if(url != null) {
 				// got data:
-				url = Translate.decode(url);
+				url = decodeCharEnt(url);
 				l.add(PATH);
 				l.add(makePath("A","href"));
 				l.add("url");
@@ -412,7 +412,7 @@ public class ExtractingParseObserver implements ParseObserver {
 				for(String a : new String[] {"target","alt","title","rel","hreflang","type"}) {
 					String v = node.getAttribute(a);
 					if(v != null) {
-						v = Translate.decode(v);
+						v = decodeCharEnt(v);
 						l.add(a);
 						l.add(v);
 					}
@@ -439,7 +439,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		public void extract(HTMLMetaData data, TagNode node, ExtractingParseObserver obs) {
 			String url = node.getAttribute("href");
 			if(url != null) {
-				url = Translate.decode(url);
+				url = decodeCharEnt(url);
 				ArrayList<String> l = new ArrayList<String>();
 				l.add(PATH);
 				l.add(makePath("AREA","href"));
@@ -461,7 +461,7 @@ public class ExtractingParseObserver implements ParseObserver {
 		public void extract(HTMLMetaData data, TagNode node, ExtractingParseObserver obs) {
 			String url = node.getAttribute("href");
 			if(url != null) {
-				url = Translate.decode(url);
+				url = decodeCharEnt(url);
 				data.setBaseHref(url);
 			}
 		}
@@ -496,7 +496,7 @@ public class ExtractingParseObserver implements ParseObserver {
 			ArrayList<String> l = new ArrayList<String>();
 			String url = node.getAttribute("action");
 			if(url != null) {
-				url = Translate.decode(url);
+				url = decodeCharEnt(url);
 				// got data:
 				l.add(PATH);
 				l.add(makePath("FORM","action"));
@@ -608,5 +608,9 @@ public class ExtractingParseObserver implements ParseObserver {
 			return m.group(2);
 		}
 		return null;
+	}
+
+	public static String decodeCharEnt(String ent) {
+		return org.apache.commons.lang.StringEscapeUtils.unescapeHtml(ent);
 	}
 }

--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -610,7 +610,11 @@ public class ExtractingParseObserver implements ParseObserver {
 		return null;
 	}
 
-	public static String decodeCharEnt(String ent) {
-		return org.apache.commons.lang.StringEscapeUtils.unescapeHtml(ent);
+	public static String decodeCharEnt(String text) {
+		try {
+			return org.apache.commons.text.StringEscapeUtils.unescapeHtml4(text);
+		} catch (Throwable e) {
+			return text;
+		}
 	}
 }

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -374,30 +374,49 @@ public class ExtractingParseObserverTest extends TestCase {
 
 	public void testHtmlParserEntityDecoding() {
 		String[][] entities = { //
-				// ampersand
+				/* ampersand */
 				{ "&amp;", "&" },
-				// apostrophe
+				/* apostrophe */
 				// TODO: { "&apos;", "'" },
-				// comma
+				/* comma */
 				// TODO: { "&comma;", "," },
-				// % percent
-				// TODO: { "percnt", "%" },
-				// ’ right single quotation mark
+				/* % percent */
+				// TODO: { "&percnt;", "%" },
+				/* ’ right single quotation mark */
 				{ "&rsquo;", "\u2019" },
-				// » right-pointing double angle quotation mark
+				/* » right-pointing double angle quotation mark */
 				{ "&raquo;", "\u00bb" },
-				// … horizontal ellipsis
+				/* … horizontal ellipsis */
 				{ "&hellip;", "\u2026" },
-				// 𤆑 CJK UNIFIED IDEOGRAPH-24191
-				// TODO: { "&#x24191;", new String(Character.toChars(0x24191)) },
-				// 😊 U+1F60A SMILING FACE WITH SMILING EYES
-				// TODO: { "&#x1F60A;", new String(Character.toChars(0x1f60a)) },
-				// must not touch "&order=" and never decode "&or" as "&or;"
-				{ "&order=lexical", "&order=lexical" },
+				/* 𤆑 CJK UNIFIED IDEOGRAPH-24191 */
+				{ "&#x24191;", new String(Character.toChars(0x24191)) },
+				/* 😊 U+1F60A SMILING FACE WITH SMILING EYES */
+				{ "&#x1F60A;", new String(Character.toChars(0x1f60a)) },
+				/*
+				 * must not decode "&or" in "&order" as "&or;" (∨ U+2228) to
+				 * avoid that unescaped ampersands in URLs cause erroneous
+				 * replacements
+				 */
+				{ "https://example.org/search?q=example&order=lexical",
+						"https://example.org/search?q=example&order=lexical" },
+				{ "https://example.org/search?q=example&amp;order=lexical",
+					"https://example.org/search?q=example&order=lexical" },
+				{ "&or;", "\u2228" },
+				/* 👎 U+1F44E THUMBS DOWN SIGN  (must not decode 0x1f44) */
+				{ "&#x1f44e;", new String(Character.toChars(0x1f44e)) },
+				/*
+				 * invalid Unicode code point: make sure that exceptions are
+				 * handled, the actual character may appear as (? or �)
+				 */
+				{ "&#xd83f;", null }, // single char of surrogate pair
+				{ "&#x110000;", null }, //
+				{ "&#2013266048;", null }, //
 		};
 		for (String[] ent : entities) {
 			String decoded = ExtractingParseObserver.decodeCharEnt(ent[0]);
-			assertEquals("Entity " + ent[0] + " not properly decoded", ent[1], decoded);
+			if (ent[1] != null) {
+				assertEquals("Entity " + ent[0] + " not properly decoded", ent[1], decoded);
+			}
 		}
 	}
 

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -385,16 +385,18 @@ public class ExtractingParseObserverTest extends TestCase {
 				// ’ right single quotation mark
 				{ "&rsquo;", "\u2019" },
 				// » right-pointing double angle quotation mark
-				{ "&raquo", "\u00bb" },
+				{ "&raquo;", "\u00bb" },
 				// … horizontal ellipsis
 				{ "&hellip;", "\u2026" },
 				// 𤆑 CJK UNIFIED IDEOGRAPH-24191
 				// TODO: { "&#x24191;", new String(Character.toChars(0x24191)) },
 				// 😊 U+1F60A SMILING FACE WITH SMILING EYES
 				// TODO: { "&#x1F60A;", new String(Character.toChars(0x1f60a)) },
+				// must not touch "&order=" and never decode "&or" as "&or;"
+				{ "&order=lexical", "&order=lexical" },
 		};
 		for (String[] ent : entities) {
-			String decoded = Translate.decode(ent[0]);
+			String decoded = ExtractingParseObserver.decodeCharEnt(ent[0]);
 			assertEquals("Entity " + ent[0] + " not properly decoded", ent[1], decoded);
 		}
 	}


### PR DESCRIPTION
- replace org.htmlparser's decode method by Apache commons `unescapeHtml`