### PR TITLE
WAT generator: do not fail on missing WARC-Filename in warcinfo record

### DIFF
--- a/src/main/java/org/archive/extract/WATExtractorOutput.java
+++ b/src/main/java/org/archive/extract/WATExtractorOutput.java
@@ -167,7 +167,7 @@ public class WATExtractorOutput implements ExtractorOutput {
 		String warcType = extractOrIO(md, "Envelope.WARC-Header-Metadata.WARC-Type");
 		String targetURI;
 		if(warcType.equals("warcinfo")) {
-			targetURI = extractOrIO(md, "Envelope.WARC-Header-Metadata.WARC-Filename");
+			targetURI = JSONUtils.extractSingle(md, "Envelope.WARC-Header-Metadata.WARC-Filename");
 		} else {
 			targetURI = extractOrIO(md, "Envelope.WARC-Header-Metadata.WARC-Target-URI");
 		}

--- a/src/main/java/org/archive/format/warc/WARCRecordWriter.java
+++ b/src/main/java/org/archive/format/warc/WARCRecordWriter.java
@@ -100,7 +100,10 @@ public class WARCRecordWriter implements WARCConstants, HttpConstants {
   {
     HttpHeaders headers = new HttpHeaders();
     headers.add(HEADER_KEY_TYPE, WARCRecordType.metadata.name());
-    headers.add(HEADER_KEY_URI, targetURI);
+    if (targetURI != null) {
+        // WARC-Target-URI is optional in metadata records
+        headers.add(HEADER_KEY_URI, targetURI);
+    }
     headers.add(HEADER_KEY_DATE, DateUtils.getLog14Date(originalDate));
     headers.add(HEADER_KEY_ID, makeRecordId());
     headers.add(HEADER_KEY_REFERS_TO, origRecordId);


### PR DESCRIPTION
fixes #23

- do not throw IOException if there is no WARC-Filename in warcinfo record
- write metadata record (corresponding to warcinfo) without WARC-Target-URI