### PR TITLE
Improve www\d*. prefix handling

### DIFF
--- a/src/main/java/org/archive/url/IAURLCanonicalizer.java
+++ b/src/main/java/org/archive/url/IAURLCanonicalizer.java
@@ -144,13 +144,9 @@ public class IAURLCanonicalizer implements URLCanonicalizer, CanonicalizerConsta
 	
 	public static final Pattern WWWN_PATTERN = Pattern.compile("(^www\\d*\\.).+\\.");
 	public static String massageHost(String host) {
-		while(true) {
-			Matcher m = WWWN_PATTERN.matcher(host);
-			if(m.find()) {
-				host = host.substring(m.group(1).length());
-			} else {
-				break;
-			}
+		Matcher m = WWWN_PATTERN.matcher(host);
+		if(m.find()) {
+			host = host.substring(m.group(1).length());
 		}
 		return host;
 	}

--- a/src/main/java/org/archive/url/IAURLCanonicalizer.java
+++ b/src/main/java/org/archive/url/IAURLCanonicalizer.java
@@ -142,12 +142,12 @@ public class IAURLCanonicalizer implements URLCanonicalizer, CanonicalizerConsta
 	}
 	
 	
-	public static final Pattern WWWN_PATTERN = Pattern.compile("^www\\d*\\.");
+	public static final Pattern WWWN_PATTERN = Pattern.compile("(^www\\d*\\.).+\\.");
 	public static String massageHost(String host) {
 		while(true) {
 			Matcher m = WWWN_PATTERN.matcher(host);
 			if(m.find()) {
-				host = host.substring(m.group(0).length());
+				host = host.substring(m.group(1).length());
 			} else {
 				break;
 			}

--- a/src/test/java/org/archive/url/BasicURLCanonicalizerTest.java
+++ b/src/test/java/org/archive/url/BasicURLCanonicalizerTest.java
@@ -33,7 +33,7 @@ public class BasicURLCanonicalizerTest extends TestCase {
 		assertEquals(14,guc.getHex('E'));
 		assertEquals(15,guc.getHex('F'));
 		assertEquals(-1,guc.getHex('G'));
-		assertEquals(-1,guc.getHex('G'));
+		assertEquals(-1,guc.getHex('g'));
 		assertEquals(-1,guc.getHex('q'));
 		assertEquals(-1,guc.getHex(' '));
 	}

--- a/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
+++ b/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
@@ -47,7 +47,7 @@ public class IAURLCanonicalizerTest extends TestCase {
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("foo.com"));
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www.foo.com"));
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www12.foo.com"));
-		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www12.www.foo.com"));
+		assertEquals("www.foo.com",IAURLCanonicalizer.massageHost("www12.www.foo.com"));
 		assertEquals("www2foo.com",IAURLCanonicalizer.massageHost("www2foo.com"));
 		assertEquals("www2foo.com",IAURLCanonicalizer.massageHost("www2.www2foo.com"));
 	}

--- a/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
+++ b/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
@@ -42,9 +42,12 @@ public class IAURLCanonicalizerTest extends TestCase {
 	}
 
 	public void testMassageHost() {
+		assertEquals("www.com",IAURLCanonicalizer.massageHost("www.com"));
+		assertEquals("www3288.com",IAURLCanonicalizer.massageHost("www3288.com"));
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("foo.com"));
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www.foo.com"));
 		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www12.foo.com"));
+		assertEquals("foo.com",IAURLCanonicalizer.massageHost("www12.www.foo.com"));
 		assertEquals("www2foo.com",IAURLCanonicalizer.massageHost("www2foo.com"));
 		assertEquals("www2foo.com",IAURLCanonicalizer.massageHost("www2.www2foo.com"));
 	}


### PR DESCRIPTION
Fixes #29 

This makes two changes to the WWWnnn prefix handling:
* doesn't remove second level domains like www1234.com
* only removes a single leading prefix rather than repeatedly removing all prefixes

It also includes a trivial fix for a duplicate test case that I noticed in my travels.