### PR TITLE
Reduce log level of two classes called by the WAT/WET extractor to avoid that log files are flooded with multiple log messages per WARC record

### DIFF
--- a/src/main/java/org/archive/extract/ExtractingResourceProducer.java
+++ b/src/main/java/org/archive/extract/ExtractingResourceProducer.java
@@ -32,8 +32,8 @@ public class ExtractingResourceProducer implements ResourceProducer {
 			if(f == null) {
 				return current;
 			}
-			if(LOG.isLoggable(Level.INFO)) {
-				LOG.info(String.format("Extracting (%s) with (%s)\n", 
+			if(LOG.isLoggable(Level.FINE)) {
+				LOG.fine(String.format("Extracting (%s) with (%s)\n",
 						current.getClass().toString(),
 						f.getClass().toString()));
 			}

--- a/src/main/java/org/archive/format/gzip/GZIPMemberSeries.java
+++ b/src/main/java/org/archive/format/gzip/GZIPMemberSeries.java
@@ -171,7 +171,7 @@ public class GZIPMemberSeries extends InputStream implements GZIPConstants {
 			throw new IOException("getNextMember() on IOException Stream at "
 					+ currentMemberStartOffset + " in " + streamContext);
 		}
-		LOG.info("getNextMember");
+		LOG.fine("getNextMember");
 
 		if(gotEOF) {
 			LOG.info("getNextMember-ATEOF");
@@ -208,9 +208,9 @@ public class GZIPMemberSeries extends InputStream implements GZIPConstants {
 		while(currentMember == null) {
 			// scan ahead for another record start:
 			long amtSkipped = decoder.alignOnMagic3(this);
-			if(LOG.isLoggable(Level.INFO)) {
+			if(LOG.isLoggable(Level.FINE)) {
 
-				LOG.info("AlignedResult:" + amtSkipped);
+				LOG.fine("AlignedResult:" + amtSkipped);
 			}
 			if(amtSkipped < 0) {
 				gotEOF = true;
@@ -256,7 +256,7 @@ public class GZIPMemberSeries extends InputStream implements GZIPConstants {
 			try {
 				currentMemberStartOffset = offset - 3;
 				header = decoder.parseHeader(this, true);
-				LOG.info("Read next GZip header...");
+				LOG.fine("Read next GZip header...");
 				currentMember = new GZIPSeriesMember(this,header);
 				state = STATE_DEFLATING;
 				
@@ -290,8 +290,8 @@ public class GZIPMemberSeries extends InputStream implements GZIPConstants {
 
 	public int read(byte[] b, int off, int len) throws IOException {
 		int amtWritten = 0;
-		if(LOG.isLoggable(Level.INFO)) {
-			LOG.info("read("+len+" bytes) bufferSize("+bufferSize+")");
+		if(LOG.isLoggable(Level.FINE)) {
+			LOG.fine("read("+len+" bytes) bufferSize("+bufferSize+")");
 		}
 		while(len > 0) {
 			if(bufferSize > 0) {
@@ -340,8 +340,8 @@ public class GZIPMemberSeries extends InputStream implements GZIPConstants {
 		if((bytes > bufferPos) || (bytes < 0)) {
 			throw new IndexOutOfBoundsException();
 		}
-		if(LOG.isLoggable(Level.INFO)) {
-			LOG.info("Returned ("+bytes+")bytes");
+		if(LOG.isLoggable(Level.FINE)) {
+			LOG.fine("Returned ("+bytes+")bytes");
 		}
 		bufferPos -= bytes;
 		bufferSize += bytes;


### PR DESCRIPTION
The logging of the classes ExtractingResourceProducer and GZIPSeriesMember is very verbose and produces per transformed WARC record multiple log messages:
```
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries returnBytes
INFO: Returned (3165)bytes
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries read
INFO: read(8 bytes) bufferSize(3165)
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries getNextMember
INFO: getNextMember
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries read
INFO: read(3 bytes) bufferSize(3157)
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries getNextMember
INFO: AlignedResult:0
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries read
INFO: read(7 bytes) bufferSize(3154)
Oct 07, 2023 5:41:49 PM org.archive.format.gzip.GZIPMemberSeries getNextMember
INFO: Read next GZip header...
Oct 07, 2023 5:41:49 PM org.archive.extract.ExtractingResourceProducer getNext
INFO: Extracting (class org.archive.resource.warc.WARCResource) with (class org.archive.resource.http.HTTPResponseResourceFactory)
```

These messages generate 40+ MB of log output per WARC file (about 1 GiB in size). To avoid that log files are flooded, this PR changes the log level for these outputs from INFO to FINE. The level for messages which might indicate potential reasons for errors are left as is.