### PR TITLE
Upgrade to a recent Hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,13 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>17.0</version>
+      <version>27.0-jre</version>
     </dependency>
 
     <dependency>
       <groupId>com.github.openjson</groupId>
       <artifactId>openjson</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
     </dependency>
 
     <dependency>
@@ -99,48 +99,14 @@
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
-      <version>0.20.2-cdh3u4</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet.jsp</groupId>
-          <artifactId>jsp-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>tomcat</groupId>
-          <artifactId>jasper-runtime</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>tomcat</groupId>
-          <artifactId>jasper-compiler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>hsqldb</groupId>
-          <artifactId>hsqldb</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>hadoop-client</artifactId>
+      <version>3.3.5</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
-      <version>0.10.0</version>
+      <version>0.17.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -153,7 +119,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
+      <version>1.16.1</version>
     </dependency>
 
     <dependency>
@@ -170,7 +136,7 @@
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>dsiutils</artifactId>
-      <version>2.7.2</version>
+      <version>2.7.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -193,14 +159,15 @@
     </dependency>
 
     <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>4.4.15</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.16</version>
     </dependency>
+
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.11.2</version>
+      <version>2.12.5</version>
     </dependency>
   </dependencies>
 
@@ -264,38 +231,5 @@
     </resources>
 
   </build>
-  <repositories>
-    <repository>
-      <id>cloudera</id>
-      <name>Cloudera Hadoop</name>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-      <layout>default</layout>
-
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>warn</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>warn</checksumPolicy>
-      </snapshots>
-    </repository>
-
-  </repositories>
-
-<!--
-  <distributionManagement>
-    <repository>
-      <id>${repository.id}</id>
-      <url>${repository.url}</url>
-    </repository>
-    <snapshotRepository>
-      <id>${snapshotRepository.id}</id>
-      <url>${snapshotRepository.url}</url>
-    </snapshotRepository>
-  </distributionManagement>
--->
 
 </project>


### PR DESCRIPTION
ia-web-commons is based on a quite old Hadoop version (0.20.2) which should be upgraded.

In production we already use a separate branch hadoop-3.2.2" (I know, branch names should not include a version number) which ia-hadoop-tools depend on.

Maybe it's time to upgrade master as well?
- (plus) having a single branch is easier for users and deployment
- (minus) this would bring ia-web-commons further apart from iipc/webarchive-commons

Detailed upgrades:
- Hadoop 0.20.2-cdh3u4 -> 3.3.5
  - depend on the lean hadoop-client instead of hadoop-core to avoid dependency exclusions
  - use mainline vanilla Hadoop instead of Cloudera libs and remove the Cloudera repository from build configuration (note: the free "Cloudera Distribution of Hadoop (CDH)" was stopped in Oct 2019)
- dependency upgrades (if also required by Hadoop, rely on this version)
  - pig 0.10.0 -> 0.17.0
  - guava 17.0 -> 27.0-jre
  - openjson 1.0.12 -> 1.0.13
  - jsoup 1.15.3 -> 1.16.1
  - dsiutils 2.7.2 -> 2.7.3
  - httpcore 4.4.15 -> 4.4.16
  - joda-time 2.11.2 -> 2.12.5