### PR TITLE
WAT extractor: do not extract page title from embedded SVG images

### DIFF
--- a/src/main/java/org/archive/resource/html/HTMLMetaData.java
+++ b/src/main/java/org/archive/resource/html/HTMLMetaData.java
@@ -31,9 +31,15 @@ public class HTMLMetaData extends MetaData implements ResourceConstants {
 	public void setBaseHref(String href) {
 		putUnlessNull(getHeader(),HTML_BASE, href);
 	}
+
 	public void setTitle(String title) {
 		putUnlessNull(getHeader(),HTML_TITLE, title);
 	}
+
+	public boolean hasTitle() {
+		return header != null && header.has(HTML_TITLE);
+	}
+
 	private void putUnlessNull(JSONObject o, String k, String v) {
 		if(o != null) {
 			try {
@@ -43,6 +49,7 @@ public class HTMLMetaData extends MetaData implements ResourceConstants {
 			}
 		}
 	}
+
 	public String[] LtoA(List<String> l) {
 		String[] a = new String[l.size()];
 		l.toArray(a);

--- a/src/test/resources/org/archive/resource/html/title-extraction-embedded-SVG.warc
+++ b/src/test/resources/org/archive/resource/html/title-extraction-embedded-SVG.warc
@@ -1,0 +1,45 @@
+WARC/1.0
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:9043ba74-5d11-4dad-97c1-d7454f8b7358>
+WARC-Target-URI: https://www.example.org/testEmbeddedSVG.html
+WARC-Date: 2024-10-14T10:05:41Z
+WARC-IP-Address: 127.0.0.1
+WARC-Block-Digest: sha1:XNN4JA3QDUN4DDEGTIPH5ZRORHYL657F
+WARC-Payload-Digest: sha1:4FUACFTG3WCL26OITZNMEPRKFP6WAAHN
+Content-Type: application/http;msgtype=response
+Content-Length: 856
+
+HTTP/1.1 200 OK
+Date: Mon, 14 Oct 2024 10:05:41 GMT
+Server: Apache/2.4.58 (Ubuntu)
+Upgrade: h2,h2c
+Connection: Upgrade, Keep-Alive
+Last-Modified: Mon, 14 Oct 2024 10:04:25 GMT
+ETag: "20a-6246cf6287f50"
+Accept-Ranges: bytes
+Content-Length: 522
+Vary: Accept-Encoding
+Keep-Alive: timeout=5, max=100
+Content-Type: text/html
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Testing title extraction with embedded SVG</title>
+<meta charset="utf-8">
+</head>
+<body>
+  <div>
+    <header>Testing title extraction with embedded SVG</header>
+    <p>This is body text...</p>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" fill="currentColor" width="1em">
+      <title>Embedded SVG</title>
+      <rect x="0" y="0" width="100%" height="100%" fill="lightblue"/>
+      <circle cx="100" cy="100" r="50" fill="red"/>
+    </svg>
+  </div>
+</body>
+</html>
+
+
+


### PR DESCRIPTION
Address commoncrawl/ia-web-commons#36:

- do not use `<title>` elements embedded in `<svg>` as page/document title
- use the first non-empty `<title>` element to set the page/document title. This is required for documents where the `<title>` is not enclosed in the `<head>` element.
  Note: HTML5 allows the `<head>` element to be ommitted, see  https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#optional-tags
- overwrite the page/document title by the content of a `<title>` element inside the `<head>` element
- for text extraction: define the title element as block element
- add unit test that correct title is extracted from a document which includes an embedded SVG image containing a title element
- extend existing unit tests to test for proper title extraction
