### PR TITLE
WAT extractor: do not add <meta itemprop="..." > from body as metadata

### DIFF
--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -669,6 +669,24 @@ public class ExtractingParseObserver implements ParseObserver {
 		public void extract(HTMLMetaData data, TagNode node, ExtractingParseObserver obs) {
 			ArrayList<String> l = getAttrList(node,"name","rel","content","http-equiv","property");
 			if(l != null) {
+				if (l.size() == 2) {
+					if (l.get(0).equals("content")) {
+						/*
+						 * drop single "content" attributes very likely stemming
+						 * from <meta itemprop="..." content="..."> schema.org
+						 * annotations embedded in the HTML body, see
+						 * https://github.com/commoncrawl/ia-web-commons/issues/40
+						 */
+						return;
+					} else {
+						/*
+						 * Single key-value metadata pair, e.g. <meta
+						 * name="..."/> (no "content") - no value or something
+						 * when wrong with attribute parsing.
+						 */
+						return;
+					}
+				}
 				data.addMeta(l);
 			}
 		}

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -166,6 +166,20 @@ public class ExtractingParseObserverTest extends TestCase {
 		}
 	}
 
+	private void checkExtractedAttributes(Resource resource, String... attributes) throws JSONException {
+		assertNotNull(resource);
+		assertTrue("Wrong instance type of Resource: " + resource.getClass(), resource instanceof HTMLResource);
+		JSONArray metas = resource.getMetaData().getJSONObject("Head").getJSONArray("Metas");
+		assertNotNull(metas);
+		JSONObject meta = metas.getJSONObject(0);
+		assertEquals(attributes.length / 2, meta.length());
+		for (int i = 0; i < attributes.length; i += 2) {
+			String key = attributes[i];
+			assertNotNull(meta.get(key));
+			assertEquals(meta.get(key), attributes[i + 1]);
+		}
+	}
+
 	private void checkLinks(Resource resource, String[][] expectedLinks) {
 		assertNotNull(resource);
 		assertTrue("Wrong instance type of Resource: " + resource.getClass(), resource instanceof HTMLResource);
@@ -439,6 +453,14 @@ public class ExtractingParseObserverTest extends TestCase {
 		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "cs-cz");
 		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "en");
 		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/xml:lang", "content", "es-MX");
+	}
+
+	public void testBodyMetaElements() throws ResourceParseException, IOException {
+		String testFileName = "meta-itemprop.warc";
+		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
+		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
+		ExtractingResourceProducer extractor = new ExtractingResourceProducer(producer, mapper);
+		checkExtractedAttributes(extractor.getNext(), "name", "robots", "content", "index,follow");
 	}
 
 	public void testHtmlParserEntityDecoding() {

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -166,17 +166,21 @@ public class ExtractingParseObserverTest extends TestCase {
 		}
 	}
 
-	private void checkExtractedAttributes(Resource resource, String... attributes) throws JSONException {
+	private void checkExtractedAttributes(Resource resource, int metaElements, int metaElementIndex,
+			String... attributes) throws JSONException {
 		assertNotNull(resource);
 		assertTrue("Wrong instance type of Resource: " + resource.getClass(), resource instanceof HTMLResource);
 		JSONArray metas = resource.getMetaData().getJSONObject("Head").getJSONArray("Metas");
 		assertNotNull(metas);
-		JSONObject meta = metas.getJSONObject(0);
+		if (metaElements > -1) {
+			assertEquals(metaElements, metas.length());
+		}
+		JSONObject meta = metas.getJSONObject(metaElementIndex);
 		assertEquals(attributes.length / 2, meta.length());
 		for (int i = 0; i < attributes.length; i += 2) {
 			String key = attributes[i];
 			assertNotNull(meta.get(key));
-			assertEquals(meta.get(key), attributes[i + 1]);
+			assertEquals(attributes[i + 1], meta.get(key));
 		}
 	}
 
@@ -252,20 +256,6 @@ public class ExtractingParseObserverTest extends TestCase {
 			if (l.length > 2 && l[2] != null) {
 				checkAnchor(anchors, l[0], l[2]);
 			}
-		}
-	}
-
-	private void checkExtractHtmlLangAttribute(Resource resource, String... langAttributes)
-			throws JSONException {
-		assertNotNull(resource);
-		assertTrue("Wrong instance type of Resource: " + resource.getClass(), resource instanceof HTMLResource);
-		JSONArray metas = resource.getMetaData().getJSONObject("Head").getJSONArray("Metas");
-		assertNotNull(metas);
-		JSONObject meta = metas.getJSONObject(0);
-		for (int i = 0; i < langAttributes.length; i += 2) {
-			String key = langAttributes[i];
-			assertNotNull(meta.get(key));
-			assertEquals(meta.get(key), langAttributes[i+1]);
 		}
 	}
 
@@ -448,11 +438,11 @@ public class ExtractingParseObserverTest extends TestCase {
 		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
 		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
 		ExtractingResourceProducer extractor = new ExtractingResourceProducer(producer, mapper);
-		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "en");
-		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "zh-CN");
-		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "cs-cz");
-		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/lang", "content", "en");
-		checkExtractHtmlLangAttribute(extractor.getNext(), "name", "HTML@/xml:lang", "content", "es-MX");
+		checkExtractedAttributes(extractor.getNext(), 1, 0, "name", "HTML@/lang", "content", "en");
+		checkExtractedAttributes(extractor.getNext(), 1, 0, "name", "HTML@/lang", "content", "zh-CN");
+		checkExtractedAttributes(extractor.getNext(), 1, 0, "name", "HTML@/lang", "content", "cs-cz");
+		checkExtractedAttributes(extractor.getNext(), 2, 0, "name", "HTML@/lang", "content", "en");
+		checkExtractedAttributes(extractor.getNext(), 1, 0, "name", "HTML@/xml:lang", "content", "es-MX");
 	}
 
 	public void testBodyMetaElements() throws ResourceParseException, IOException {
@@ -460,7 +450,9 @@ public class ExtractingParseObserverTest extends TestCase {
 		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
 		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
 		ExtractingResourceProducer extractor = new ExtractingResourceProducer(producer, mapper);
-		checkExtractedAttributes(extractor.getNext(), "name", "robots", "content", "index,follow");
+		Resource resource = extractor.getNext();
+		checkExtractedAttributes(resource, 2, 0, "name", "HTML@/lang", "content", "en");
+		checkExtractedAttributes(resource, 2, 1, "name", "robots", "content", "index,follow");
 	}
 
 	public void testHtmlParserEntityDecoding() {

--- a/src/test/resources/org/archive/resource/html/meta-itemprop.warc
+++ b/src/test/resources/org/archive/resource/html/meta-itemprop.warc
@@ -1,0 +1,35 @@
+WARC/1.0
+WARC-Type: response
+WARC-Date: 2024-12-05T10:47:02Z
+Content-Length: 710
+Content-Type: application/http; msgtype=response
+WARC-Target-URI: https://www.example.org/
+WARC-Identified-Payload-Type: text/html
+
+HTTP/1.1 200 
+content-type: text/html; charset=UTF-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name=robots content="index,follow">
+	<title>Test</title>
+</head>
+<body>
+<!-- from https://schema.org/docs/gs.html#advanced_missing -->
+<div itemscope itemtype="https://schema.org/Offer">
+  <span itemprop="name">Blend-O-Matic</span>
+  <span itemprop="price">$19.95</span>
+  <div itemprop="reviews" itemscope itemtype="https://schema.org/AggregateRating">
+    <img src="four-stars.jpg" />
+    <meta itemprop="ratingValue" content="4" />
+    <meta itemprop="bestRating" content="5" />
+    Based on <span itemprop="ratingCount">25</span> user ratings
+  </div>
+</div>
+</body>
+</html>
+
+
+


### PR DESCRIPTION
(fixes #40)

Do not add metadata with a single key-value pair, such as `content = '...'`, require at least two key-value pairs.

Add unit test to proof that `<meta itemprop="..." content="...">` annotations are ignored.
