### PR TITLE
WAT: Duplicated payload metadata values for "Actual-Content-Length" and "Trailing-Slop-Length"

### DIFF
--- a/src/main/java/org/archive/resource/arc/ARCResource.java
+++ b/src/main/java/org/archive/resource/arc/ARCResource.java
@@ -64,10 +64,12 @@ implements ResourceConstants, ARCConstants, EOFObserver {
 		}
 	}
 
+	@Override
 	public InputStream getInputStream() {
 		return new EOFNotifyingInputStream(digIS, this);
 	}
 
+	@Override
 	public void notifyEOF() throws IOException {
 		metaData.putLong(PAYLOAD_LENGTH, countingIS.getCount());
 		String digString = Base32.encode(digIS.getMessageDigest().digest());

--- a/src/main/java/org/archive/resource/http/HTTPHeadersResourceFactory.java
+++ b/src/main/java/org/archive/resource/http/HTTPHeadersResourceFactory.java
@@ -31,6 +31,7 @@ implements ResourceFactory, ResourceConstants {
 		parser = new HttpHeaderParser();
 	}
 
+	@Override
 	public Resource getResource(InputStream is, MetaData parentMetaData,
 			ResourceContainer container) throws ResourceParseException,
 			IOException {
@@ -40,9 +41,13 @@ implements ResourceFactory, ResourceConstants {
 			if(headers.isCorrupt()) {
 				parentMetaData.putBoolean(HTTP_HEADERS_CORRUPT, true);
 			}
-			parentMetaData.putLong(PAYLOAD_LENGTH, bytes);
-			
-			parentMetaData.putLong(PAYLOAD_SLOP_BYTES, StreamCopy.readToEOF(is));
+			if (!parentMetaData.has(PAYLOAD_LENGTH) || bytes != parentMetaData.getLong(PAYLOAD_LENGTH)) {
+				parentMetaData.putLong(PAYLOAD_LENGTH, bytes);
+			}
+			long trailingSlopBytes = StreamCopy.readToEOF(is);
+			if (!parentMetaData.has(PAYLOAD_SLOP_BYTES) || trailingSlopBytes > 0) {
+				parentMetaData.putLong(PAYLOAD_SLOP_BYTES, trailingSlopBytes);
+			}
 			if(type != null) {
 				parentMetaData.putString(PAYLOAD_CONTENT_TYPE, type);
 			}

--- a/src/test/java/org/archive/resource/arc/ARCResourceTest.java
+++ b/src/test/java/org/archive/resource/arc/ARCResourceTest.java
@@ -1,0 +1,48 @@
+package org.archive.resource.arc;
+
+
+import static org.archive.resource.ResourceConstants.PAYLOAD_LENGTH;
+import static org.archive.resource.ResourceConstants.PAYLOAD_SLOP_BYTES;
+
+import java.io.IOException;
+
+import org.archive.extract.ExtractingResourceFactoryMapper;
+import org.archive.extract.ExtractingResourceProducer;
+import org.archive.extract.ProducerUtils;
+import org.archive.extract.ResourceFactoryMapper;
+import org.archive.resource.Resource;
+import org.archive.resource.ResourceParseException;
+import org.archive.resource.ResourceProducer;
+import org.archive.util.StreamCopy;
+
+import com.github.openjson.JSONObject;
+
+import junit.framework.TestCase;
+
+public class ARCResourceTest extends TestCase {
+
+	public void testARCResource() throws ResourceParseException, IOException {
+		String testFileName = "../../format/arc/IAH-20080430204825-00000-blackbook-truncated.arc";
+		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
+		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
+		ExtractingResourceProducer extractor = new ExtractingResourceProducer(producer, mapper);
+
+		Resource resource = extractor.getNext();
+
+		while (resource != null) {
+			JSONObject payloadMD = resource.getMetaData().getTopMetaData().getJSONObject("Envelope")
+					.getJSONObject("Payload-Metadata");
+			System.err.println(payloadMD);
+
+			if (payloadMD.has(PAYLOAD_LENGTH)) {
+				assertTrue(payloadMD.getLong(PAYLOAD_LENGTH) != -1);
+			}
+			if (payloadMD.has(PAYLOAD_SLOP_BYTES)) {
+				// does not occur with the tested ARC file
+			}
+
+			StreamCopy.readToEOF(resource.getInputStream());
+			resource = extractor.getNext();
+		}
+	}
+}

--- a/src/test/java/org/archive/resource/warc/WARCResourceTest.java
+++ b/src/test/java/org/archive/resource/warc/WARCResourceTest.java
@@ -1,0 +1,46 @@
+package org.archive.resource.warc;
+
+import static org.archive.resource.ResourceConstants.PAYLOAD_LENGTH;
+import static org.archive.resource.ResourceConstants.PAYLOAD_SLOP_BYTES;
+
+import java.io.IOException;
+
+import org.archive.extract.ExtractingResourceFactoryMapper;
+import org.archive.extract.ExtractingResourceProducer;
+import org.archive.extract.ProducerUtils;
+import org.archive.extract.ResourceFactoryMapper;
+import org.archive.resource.Resource;
+import org.archive.resource.ResourceParseException;
+import org.archive.resource.ResourceProducer;
+import org.archive.util.StreamCopy;
+
+import com.github.openjson.JSONObject;
+
+import junit.framework.TestCase;
+
+public class WARCResourceTest extends TestCase {
+
+	public void testWARCResource() throws ResourceParseException, IOException {
+		String testFileName = "../../format/warc/IAH-urls-wget.warc";
+		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
+		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
+		ExtractingResourceProducer extractor = new ExtractingResourceProducer(producer, mapper);
+
+		Resource resource = extractor.getNext();
+
+		while (resource != null) {
+			JSONObject payloadMD = resource.getMetaData().getTopMetaData().getJSONObject("Envelope")
+					.getJSONObject("Payload-Metadata");
+
+			if (payloadMD.has(PAYLOAD_LENGTH)) {
+				assertTrue(payloadMD.getLong(PAYLOAD_LENGTH) != -1);
+			}
+			if (payloadMD.has(PAYLOAD_SLOP_BYTES)) {
+				assertEquals(4, payloadMD.getLong(PAYLOAD_SLOP_BYTES));
+			}
+
+			StreamCopy.readToEOF(resource.getInputStream());
+			resource = extractor.getNext();
+		}
+	}
+}


### PR DESCRIPTION
fixes #43
- avoid to add a duplicated "Actual-Content-Length" value
- do not add a second value of "Trailing-Slop-Length" if 0