### PR TITLE
Improve WET text extraction, address #45 and #46

### DIFF
--- a/src/main/java/org/archive/format/text/html/CDATALexer.java
+++ b/src/main/java/org/archive/format/text/html/CDATALexer.java
@@ -1,37 +1,96 @@
 package org.archive.format.text.html;
 
 import org.htmlparser.Node;
+import org.htmlparser.Text;
 import org.htmlparser.lexer.Lexer;
 import org.htmlparser.util.ParserException;
+
+import static org.archive.format.text.html.NodeUtils.SCRIPT_TAG_NAME;
+import static org.archive.format.text.html.NodeUtils.STYLE_TAG_NAME;
 
 public class CDATALexer extends Lexer {
 	private static final long serialVersionUID = -8513653556979405106L;
 	private Node cached;
-	private boolean inCSS;
 	private boolean inJS;
-	private boolean cachedJS = false;
+	private boolean inCSS;
+
+	private static enum STATE { DEFAULT, START_JS, START_CSS };
+	private STATE state = STATE.DEFAULT;
+
+	private int start = -1;
+	private int end = -1;
 
 	@Override
 	public Node nextNode() throws ParserException {
-		inJS = false;
-		inCSS = false;
-		if(cached != null) {
+		if (cached != null) {
+			inJS = inCSS = false;
 			Node tmp = cached;
 			cached = null;
-			inJS = cachedJS;
-			inCSS = !cachedJS;
 			return tmp;
 		}
-		Node got = super.nextNode();
-		if(NodeUtils.isNonEmptyOpenTagNodeNamed(got, "SCRIPT")) {
-			cached = super.parseCDATA(true);
-			cachedJS = true;
-		} else if (NodeUtils.isNonEmptyOpenTagNodeNamed(got, "STYLE")) {
-			cached = super.parseCDATA(true);
-			cachedJS = false;
+		Node got = null;
+		switch (state) {
+		case START_JS:
+			got = super.parseCDATA(false);
+			if (got != null) {
+				inJS = true;
+			}
+			break;
+		case START_CSS:
+			got = super.parseCDATA(false);
+			if (got != null) {
+				inCSS = true;
+			}
+			break;
+		default:
+			break;
+		}
+		if (got != null) {
+			Text t = (Text) got;
+			start = t.getStartPosition();
+			end = t.getEndPosition();
+			while ((t = (Text) super.parseCDATA(false)) != null) {
+				end = t.getEndPosition();
+			}
+			while ((got = super.nextNode()) != null) {
+				if (inJS) {
+					if (NodeUtils.isCloseTagNodeNamed(got, SCRIPT_TAG_NAME)) {
+						cached = got;
+						state = STATE.DEFAULT;
+						return createStringNode(getPage(), start, end);
+					} else {
+						end = got.getEndPosition();
+					}
+				} else if (inCSS) {
+					if (NodeUtils.isCloseTagNodeNamed(got, STYLE_TAG_NAME)) {
+						cached = got;
+						state = STATE.DEFAULT;
+						return createStringNode(getPage(), start, end);
+					} else {
+						end = got.getEndPosition();
+					}
+				}
+			}
+			t = createStringNode(getPage(), start, end);
+			state = STATE.DEFAULT;
+			start = end = -1;
+			return t;
+		}
+		got = super.nextNode();
+		if (NodeUtils.isNonEmptyOpenTagNodeNamed(got, SCRIPT_TAG_NAME)) {
+			state = STATE.START_JS;
+		} else if (NodeUtils.isNonEmptyOpenTagNodeNamed(got, STYLE_TAG_NAME)) {
+			state = STATE.START_CSS;
+		} else if (NodeUtils.isCloseTagNodeNamed(got, SCRIPT_TAG_NAME)) {
+			state = STATE.DEFAULT;
+			inJS = false;
+		} else if (NodeUtils.isCloseTagNodeNamed(got, STYLE_TAG_NAME)) {
+			state = STATE.DEFAULT;
+			inCSS = false;
 		}
 		return got;
 	}
+
 	public boolean inJS() {
 		return inJS;
 	}

--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -59,10 +59,10 @@ public class ExtractingParseObserver implements ParseObserver {
 	private final static int MAX_TEXT_LEN = 128;
 
 	private final static String[] BLOCK_ELEMENTS = { "address", "article", "aside", "blockquote", "body", "br",
-			"button", "canvas", "caption", "col", "colgroup", "dd", "div", "dl", "dt", "embed", "fieldset",
+			"button", "canvas", "caption", "center", "col", "colgroup", "dd", "div", "dl", "dt", "embed", "fieldset",
 			"figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
-			"li", "map", "noscript", "object", "ol", "output", "p", "pre", "progress", "section", "table", "tbody",
-			"textarea", "tfoot", "th", "thead", "title", "tr", "ul", "video" };
+			"li", "map", "noframes", "noscript", "object", "ol", "output", "p", "pre", "progress", "section", "table",
+			"tbody", "textarea", "tfoot", "th", "thead", "title", "tr", "ul", "video" };
 	private static final Set<String> blockElements;
 	/* inline elements which content is not melted with surrounding words */
 	private final static String[] INLINE_ELEMENTS_SPACING = { "address", "cite", "details", "datalist", "iframe", "img",


### PR DESCRIPTION
A work around to read until closing `</script>` or `</style>` tag. This avoids that scripts or styles containing HTML snippets end prematurely and add bad textual content.

Note: this is more a work-around because the underlying HTML parser library [htmlparser.org](https://mvnrepository.com/artifact/org.htmlparser/htmlparser) is not maintained since 14 years. Fixing the issue there is not possible. Main changes:
- use [Lexer.parseCDATA(false)](https://htmlparser.sourceforge.net/javadoc/org/htmlparser/lexer/Lexer.html#parseCDATA(boolean)), disabling the "quotesmart" feature which tries to ignore HTML end tags inside quotes. The "quotesmart" sometimes fails which causes that the script/style block is prematurely "closed" by a `</[a-z]` sequence.
- if the state is inside a script/style block, loop until the parser returns a closing `</script>` or `</style>` tag. Append everything else to the cached text value of the script/style block.

Tested so far:
1. the WET extracts of the pages referenced in #45 and #46 do not anymore contain CSS resp. Javascript snippets. In addition, some more text is extracted.
2. a comparison "before and after" for about 1000 WET records also shows better text extracts in overall. There are few regressions, see below.
3. verified the WAT extraction which is also affected by this fix: there are very small differences in the number of extracted URLs.

Regressions (less text extracted now):
- if the script or style block includes an opening HTML comment marker (`<!--`) but no closing marker, the closing `</script>` resp. `</style>` element is not found. That is everything until another HTML comment end marker (`-->`) or until end of file is consumed as comment by the parser. Not fixable from outside of "htmlparser.org": a fix would require to override the method [org.htmlparser.lexer.Lexer.parseString(...)](https://htmlparser.sourceforge.net/javadoc/org/htmlparser/lexer/Lexer.html#parseString(int,%20boolean)) with a version ignoring HTML comments only if inside a script or style block.
- templates including HTML snippets are now ignored (not really a regression, but less extracted text). For example:
  ```html
  <script type="text/x-ph-tmpl" ...><!-- HTML snippet --></script>
  <script type="text/html" id="tmpl-..."><!-- HTML snippet --></script>
  <script id="ckyBannerTemplate" type="text/template"><!-- HTML snippet --></script>
  ```
